### PR TITLE
Bugfix/single storeview bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+- Issue when pushing Magento URL to Wordpress for single-store view
+
 ## [0.7.0] - 2021-02-10
 ### Improvement
 - Update dependency for mooore/magento2-module-wordpress-integration to ^0.3

--- a/Plugin/Controller/Adminhtml/Page/DeletePlugin.php
+++ b/Plugin/Controller/Adminhtml/Page/DeletePlugin.php
@@ -7,9 +7,9 @@ namespace Mooore\WordpressIntegrationCms\Plugin\Controller\Adminhtml\Page;
 use Magento\Cms\Controller\Adminhtml\Page\Delete as DeleteController;
 use Magento\Cms\Model\PageRepository;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Message\ManagerInterface as MessageManager;
 use Mooore\WordpressIntegrationCms\Model\RemotePageRepository;
 use Mooore\WordpressIntegrationCms\Model\Config;
-use Magento\Framework\Message\ManagerInterface as MessageManager;
 
 class DeletePlugin
 {

--- a/Plugin/Controller/Adminhtml/Page/MassDeletePlugin.php
+++ b/Plugin/Controller/Adminhtml/Page/MassDeletePlugin.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Mooore\WordpressIntegrationCms\Plugin\Controller\Adminhtml\Page;
 
 use Magento\Cms\Controller\Adminhtml\Page\MassDelete as MassDeleteController;
-use Magento\Framework\Exception\LocalizedException;
-use Magento\Ui\Component\MassAction\Filter;
 use Magento\Cms\Model\ResourceModel\Page\CollectionFactory;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Message\ManagerInterface as MessageManager;
+use Magento\Ui\Component\MassAction\Filter;
 use Mooore\WordpressIntegrationCms\Model\RemotePageRepository;
 use Mooore\WordpressIntegrationCms\Model\Config;
-use Magento\Framework\Message\ManagerInterface as MessageManager;
 
 class MassDeletePlugin
 {

--- a/Plugin/Model/SavePlugin.php
+++ b/Plugin/Model/SavePlugin.php
@@ -83,10 +83,6 @@ class SavePlugin
 
     private function buildUrlFromPage(Page $page): string
     {
-        if (!array_key_exists(0, $page->getStoreId())) {
-            return '';
-        }
-
         try {
             $storeIds = $page->getStoreId();
             if (!count($storeIds)) {

--- a/Plugin/Model/SavePlugin.php
+++ b/Plugin/Model/SavePlugin.php
@@ -83,24 +83,18 @@ class SavePlugin
 
     private function buildUrlFromPage(Page $page): string
     {
-        try {
-            $storeIds = $page->getStoreId();
-            if (!count($storeIds)) {
-                return '';
-            }
-
-            try {
-                $firstStoreId = $storeIds[0];
-                $storeFromPage = $this->storeManager->getStore($firstStoreId);
-
-                return $storeFromPage->getBaseUrl() . $page->getIdentifier();
-            } catch (NoSuchEntityException $e) {
-                return '';
-            }
-        } catch (NoSuchEntityException $e) {
+        $storeIds = $page->getStoreId();
+        if (!count($storeIds)) {
             return '';
         }
 
-        return $storeFromPage->getBaseUrl() . $page->getIdentifier();
+        try {
+            $firstStoreId = $storeIds[0];
+            $storeFromPage = $this->storeManager->getStore($firstStoreId);
+
+            return $storeFromPage->getBaseUrl() . $page->getIdentifier();
+        } catch (NoSuchEntityException $e) {
+            return '';
+        }
     }
 }

--- a/Plugin/Model/SavePlugin.php
+++ b/Plugin/Model/SavePlugin.php
@@ -5,16 +5,16 @@ declare(strict_types=1);
 namespace Mooore\WordpressIntegrationCms\Plugin\Model;
 
 use Magento\Cms\Model\PageRepository;
-use Magento\Framework\Controller\ResultInterface;
-use Magento\Framework\Exception\LocalizedException;
-use Mooore\WordpressIntegrationCms\Model\HttpClient\Page as PageClient;
-use Mooore\WordpressIntegrationCms\Model\RemotePageRepository;
 use Magento\Cms\Model\Page;
 use Magento\Cms\Api\Data\PageInterface;
-use Mooore\WordpressIntegrationCms\Model\Config;
+use Magento\Framework\Controller\ResultInterface;
+use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Message\ManagerInterface as MessageManager;
-use Magento\Store\Model\StoreManagerInterface;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Store\Model\StoreManagerInterface;
+use Mooore\WordpressIntegrationCms\Model\HttpClient\Page as PageClient;
+use Mooore\WordpressIntegrationCms\Model\RemotePageRepository;
+use Mooore\WordpressIntegrationCms\Model\Config;
 
 class SavePlugin
 {
@@ -92,11 +92,11 @@ class SavePlugin
             if (!count($storeIds)) {
                 return '';
             }
-            
+
             try {
                 $firstStoreId = $storeIds[0];
                 $storeFromPage = $this->storeManager->getStore($firstStoreId);
-                
+
                 return $storeFromPage->getBaseUrl() . $page->getIdentifier();
             } catch (NoSuchEntityException $e) {
                 return '';

--- a/Plugin/Model/SavePlugin.php
+++ b/Plugin/Model/SavePlugin.php
@@ -88,7 +88,19 @@ class SavePlugin
         }
 
         try {
-            $storeFromPage = $this->storeManager->getStore($page->getStoreId()[0]);
+            $storeIds = $page->getStoreId();
+            if (!count($storeIds)) {
+                return '';
+            }
+            
+            try {
+                $firstStoreId = $storeIds[0];
+                $storeFromPage = $this->storeManager->getStore($firstStoreId);
+                
+                return $storeFromPage->getBaseUrl() . $page->getIdentifier();
+            } catch (NoSuchEntityException $e) {
+                return '';
+            }
         } catch (NoSuchEntityException $e) {
             return '';
         }


### PR DESCRIPTION
I noticed a bug when assigning a Wordpress page to a single store view. After a careful investigation I discovered that our PageHelper class was not really fit for this feature. After unsuccessfully wrestling with Magento 2's own UrlBuilderInterface I decided to build my own buildUrlFromPage() function to do the work for me.

Of course I have tested this on my environment without much hassle. 

I would like to know what you think!