### PR TITLE
ADD: wp-embed-responsive class on body

### DIFF
--- a/view/frontend/layout/cms_wp_content.xml
+++ b/view/frontend/layout/cms_wp_content.xml
@@ -7,6 +7,7 @@
     </head>
     <body>
         <attribute name="class" value="wp-content"/>
+        <attribute name="class" value="wp-embed-responsive"/>
         <referenceContainer name="content" htmlTag="div" htmlClass="entry-content"/>
     </body>
 </page>


### PR DESCRIPTION
By default embedded videos (for example YouTube), does not get properly aligned by aspect ratio, without using the body-class "wp-embed-responsive" . This PR adds this.
![image](https://user-images.githubusercontent.com/10142882/116880152-f3da4b80-ac21-11eb-8832-5613671ee2ce.png)
