### PR TITLE
IMP: Sometimes double-dashes gets encoded to one from API

### DIFF
--- a/Plugin/Model/PagePlugin.php
+++ b/Plugin/Model/PagePlugin.php
@@ -51,8 +51,11 @@ class PagePlugin
 
         $html = $remotePage['content']['rendered'];
 
-        $html = preg_replace_callback("{{(.*)}}", function ($matches) {
+        $html = preg_replace_callback("{{{(.*)}}}", function ($matches) {
             $match = $matches[0];
+
+            // Solve wierd encoding from Wordpress API regarding double-dashes
+            $match = preg_replace('/([^\s])&#8211;([^\s])/m', '$1--$2', $match);
 
             $match = html_entity_decode($match);
             $match = str_replace('”', '"', $match); // Opening quote


### PR DESCRIPTION
Sometimes doubledashes gets translated to one dash, this will check every shortcode on the page, see if there's an encoded dash *between 2 letters*, and converts that to a double dash.

A couple examples on what is happening now:

Wordpress Source | Wordpress API result | Which Magento translates to..
-- | -- | --
1-1 | 1-1 | 1-1
1--1 | 1&#8211;1 | 1-1
1 - 1 | 1 &#8211; 1 | 1 - 1
1 -- 1 | 1 &#8212; 1 | 1 — 1
f--q | f&#8211;q | 1-1

