### PR TITLE
Add description for page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.10.3] - 2022-07-04
+## [0.10.4] - 2022-07-04
 ### Added
 - Add meta description from post excerpt
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.10.3] - 2022-07-04
 ### Added
 - Add meta description from post excerpt
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add meta description from post excerpt
 
 ## [0.10.3] - 2022-06-29
 ### Fixed

--- a/Controller/Blog/View.php
+++ b/Controller/Blog/View.php
@@ -73,7 +73,7 @@ class View extends Action implements HttpGetActionInterface
         $this->resultPage->getConfig()->getTitle()->set($page['title']['rendered']);
         
         $descriptionRaw = $page['excerpt']['rendered'];
-        if($descriptionRaw) {
+        if ($descriptionRaw) {
             $description = trim(strip_tags($descriptionRaw));
             $this->resultPage->getConfig()->setDescription($description);
         }

--- a/Controller/Blog/View.php
+++ b/Controller/Blog/View.php
@@ -71,6 +71,12 @@ class View extends Action implements HttpGetActionInterface
         }
 
         $this->resultPage->getConfig()->getTitle()->set($page['title']['rendered']);
+        
+        $descriptionRaw = $page['excerpt']['rendered'];
+        if($descriptionRaw) {
+            $description = trim(strip_tags($descriptionRaw));
+            $this->resultPage->getConfig()->setDescription($description);
+        }
 
         $page = $this->resultFactory->create(ResultFactory::TYPE_PAGE);
         $layout = $page->getLayout();


### PR DESCRIPTION
This gets the excerpt (custom or excerpt from blog) and set this as the page description. Problem now is that for every blog don't have an description so the fallback is triggered. That means multiple pages have the same description = bad SEO.